### PR TITLE
Reduced incidence of autonav starting up when clicking planets (and planet indicators)

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -1237,7 +1237,7 @@ static void input_clickevent( SDL_Event* event )
          if (planet_hasService(pnt, PLANET_SERVICE_LAND)) {
             if ((pnt->faction >= 0) && (areEnemies( player.p->faction, pnt->faction ) && !pnt->bribed))
                player_hailPlanet();
-            else if (vect_dist2(&player.p->solid->pos,&pnt->pos) > pow2(pnt->radius))
+            else if (vect_dist2(&player.p->solid->pos,&pnt->pos) > pow2(pnt->radius * 5))
                player_autonavStart();
             else
                player_land();


### PR DESCRIPTION
Changed the distance required for clicking on a planet. Now 5x the radius. This prevents the annoying behavior of causing you to zip past the planet when you're trying to use the mouse to land, without preventing you from starting autonav by clicking the indicator on the edge.

This is an alternative to #152, which deleted the behavior of engaging autonav this way entirely. This one just reduces it. Incidentally, it seems the reduction amount I chose is perfect; when zoomed out due to targeting a ship, it seems to be exactly the distance when the planet indicators on the edge show up.