### PR TITLE
Removed the "pause instead of abort" option.

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -192,7 +192,6 @@ void conf_setGameplayDefaults (void)
    conf.save_compress         = SAVE_COMPRESSION_DEFAULT;
    conf.mouse_thrust          = MOUSE_THRUST_DEFAULT;
    conf.autonav_reset_speed   = AUTONAV_RESET_SPEED_DEFAULT;
-   conf.autonav_pause         = AUTONAV_PAUSE_DEFAULT;
    conf.zoom_manual           = MANUAL_ZOOM_DEFAULT;
 }
 
@@ -414,7 +413,6 @@ int conf_loadConfig ( const char* file )
       conf_loadInt("afterburn_sensitivity",conf.afterburn_sens);
       conf_loadInt("mouse_thrust",conf.mouse_thrust);
       conf_loadFloat("autonav_abort",conf.autonav_reset_speed);
-      conf_loadBool("autonav_pause",conf.autonav_pause);
       conf_loadBool("devmode",conf.devmode);
       conf_loadBool("devautosave",conf.devautosave);
       conf_loadBool("conf_nosave",conf.nosave);
@@ -1049,7 +1047,6 @@ int conf_saveConfig ( const char* file )
    conf_saveEmptyLine();
 
    conf_saveComment("If set, the game will pause when damage is received, instead of aborting the autonav.");
-   conf_saveBool("autonav_pause",conf.autonav_pause);
    conf_saveEmptyLine();
 
    conf_saveComment("Enables developer mode (universe editor and the likes)");

--- a/src/conf.h
+++ b/src/conf.h
@@ -16,8 +16,7 @@
 #define TIME_COMPRESSION_DEFAULT_MULT        200   /**< Default level of time compression multiplier. */
 #define SAVE_COMPRESSION_DEFAULT             1     /**< Whether or not saved games should be compressed. */
 #define MOUSE_THRUST_DEFAULT                 1     /**< Whether or not to use mouse thrust controls. */
-#define AUTONAV_RESET_SPEED_DEFAULT          1.    /**< Shield level (0-1) to reset autonav speed at. 1 means at missile lock, 0 means at armour damage. */
-#define AUTONAV_PAUSE_DEFAULT                0     /**< Whether or not the game should pause when autonav is aborted. */
+#define AUTONAV_RESET_SPEED_DEFAULT          1.    /**< Shield level (0-1) to reset autonav speed at. 1 means at enemy presence, 0 means at armour damage. */
 #define MANUAL_ZOOM_DEFAULT                  0     /**< Whether or not to enable manual zoom controls. */
 #define INPUT_MESSAGES_DEFAULT               5     /**< Amount of messages to display. */
 /* Video options */
@@ -129,7 +128,6 @@ typedef struct PlayerConf_s {
    unsigned int afterburn_sens; /**< Afterburn sensibility. */
    int mouse_thrust; /**< Whether mouse flying controls thrust. */
    double autonav_reset_speed; /**< Condition for resetting autonav speed. */
-   int autonav_pause;/**< Pauses game instead of aborting autonav. */
    int nosave; /**< Disables conf saving. */
    int devmode; /**< Developer mode. */
    int devautosave; /**< Developer mode autosave. */

--- a/src/options.c
+++ b/src/options.c
@@ -273,10 +273,6 @@ static void opt_gameplay( unsigned int wid )
    y -= 25;
 
    window_addCheckbox( wid, x, y, cw, 20,
-         "chkAutonavPause", "Pause instead of aborting Autonav", NULL, conf.autonav_pause );
-   y -= 25;
-
-   window_addCheckbox( wid, x, y, cw, 20,
          "chkZoomManual", "Enable manual zoom control", NULL, conf.zoom_manual );
    y -= 25;
    window_addCheckbox( wid, x, y, cw, 20,
@@ -325,7 +321,6 @@ static void opt_gameplaySave( unsigned int wid, char *str )
    conf.zoom_manual = window_checkboxState( wid, "chkZoomManual" );
    conf.mouse_thrust = window_checkboxState(wid, "chkMouseThrust" );
    conf.save_compress = window_checkboxState( wid, "chkCompress" );
-   conf.autonav_pause = window_checkboxState( wid, "chkAutonavPause" );
    
    /* Faders. */
    conf.autonav_reset_speed = window_getFaderValue(wid, "fadAutonav");

--- a/src/player_autonav.c
+++ b/src/player_autonav.c
@@ -254,15 +254,6 @@ void player_autonavAbort( const char *reason )
       return;
 
    if (player_isFlag(PLAYER_AUTONAV)) {
-      if (conf.autonav_pause && reason) {
-         /* Keep it from re-pausing before you can react */
-         if (autopause_timer > 0) return;
-         player_message("\erGame paused: %s!", reason);
-         player_autonavResetSpeed();
-         autopause_timer = 2.;
-         pause_game();
-         return;
-      }
       if (reason != NULL)
          player_message("\erAutonav aborted: %s!", reason);
       else


### PR DESCRIPTION
This was clearly designed to use in conjunction with the old autonav
abortion behavior. player_autonavAbort is still used in some places,
but I don't think it's particularly useful to give the player the
option to pause instead of abort in these places.

Also includes a comment fix that I apparently forgot to merge previously.