### PR TITLE
Made it possible to activate outfits that are cooling down.

### DIFF
--- a/src/pilot_weapon.c
+++ b/src/pilot_weapon.c
@@ -165,6 +165,7 @@ void pilot_weapSetAIClear( Pilot* p )
 void pilot_weapSetPress( Pilot* p, int id, int type )
 {
    int i, l, on, n;
+   double d;
    PilotWeaponSet *ws;
 
    ws = pilot_weapSet(p,id);
@@ -194,7 +195,7 @@ void pilot_weapSetPress( Pilot* p, int id, int type )
 
       case WEAPSET_TYPE_ACTIVE:
          /* The behaviour here is more complex. What we do is consider a group
-          * to be entirely off if not all outfits are either on or cooling down.
+          * to be entirely off if not all outfits are on.
           * In the case it's deemed to be off, all outfits that are off get turned
           * on, otherwise all outfits that are on are turrned to cooling down. */
          /* Only care about presses. */
@@ -209,7 +210,7 @@ void pilot_weapSetPress( Pilot* p, int id, int type )
          on = 1;
          l  = array_size(ws->slots);
          for (i=0; i<l; i++) {
-            if (ws->slots[i].slot->state == PILOT_OUTFIT_OFF) {
+            if (ws->slots[i].slot->state != PILOT_OUTFIT_ON) {
                on = 0;
                break;
             }
@@ -228,13 +229,21 @@ void pilot_weapSetPress( Pilot* p, int id, int type )
          /* Turn them on. */
          else {
             for (i=0; i<l; i++) {
-               if (ws->slots[i].slot->state != PILOT_OUTFIT_OFF)
+               if ( (ws->slots[i].slot->state != PILOT_OUTFIT_OFF) &&
+                     (ws->slots[i].slot->state != PILOT_OUTFIT_COOLDOWN) )
                   continue;
                if (outfit_isAfterburner(ws->slots[i].slot->outfit))
                   pilot_afterburn( p );
                else {
-                  ws->slots[i].slot->state  = PILOT_OUTFIT_ON;
-                  ws->slots[i].slot->stimer = outfit_duration( ws->slots[i].slot->outfit );
+                  if (ws->slots[i].slot->state == PILOT_OUTFIT_OFF) {
+                     ws->slots[i].slot->state  = PILOT_OUTFIT_ON;
+                     ws->slots[i].slot->stimer = outfit_duration( ws->slots[i].slot->outfit );
+                  }
+                  else {
+                     ws->slots[i].slot->state  = PILOT_OUTFIT_ON;
+                     d = outfit_duration( ws->slots[i].slot->outfit );
+                     ws->slots[i].slot->stimer = d - (d * ws->slots[i].slot->stimer / outfit_cooldown( ws->slots[i].slot->outfit ));
+                  }
                }
                n++;
             }


### PR DESCRIPTION
It makes no sense for a somewhat hot outfit to have to be completely
cool before you can start it up again, and it degrades the usefulness
of outfits with a cooldown period (such as the Emergency Shield Booster)
in a way that's annoying. With this change, the cooldown period still limits
the use of such outfits the same amount, but gives the player full
control over when this use is.

I wanted to do this with beam weapons as well, but couldn't figure
out how to.