### PR TITLE
Don't lower the player's reputation unless in the faction's territory.

### DIFF
--- a/dat/factions/standing/flf.lua
+++ b/dat/factions/standing/flf.lua
@@ -8,6 +8,7 @@ _fdelta_distress = {-0.5, 0} -- Maximum change constraints
 _fdelta_kill     = {-5, 1.5} -- Maximum change constraints
 _fcap_misn     = 50 -- Starting mission cap, gets overwritten
 _fcap_misn_var = "_fcap_flf"
+_fextern_penalty = true
 _fthis         = faction.get("FLF")
 
 

--- a/dat/factions/standing/skel.lua
+++ b/dat/factions/standing/skel.lua
@@ -12,6 +12,10 @@ _fcap_misn       = 30 -- Starting mission cap, gets overwritten
 _fcap_misn_var   = nil -- Mission variable to use for limits
 _fcap_mod_sec    = 0.3 -- Modulation from secondary
 
+-- Whether or not the faction should get mad for attacking them or their
+-- allies outside of their territory.
+_fextern_penalty = false
+
 
 --[[
    @brief Clamps a value x between low and high.
@@ -94,6 +98,21 @@ function default_hit( current, amount, source, secondary )
       end
    end
 
+   if not _fextern_penalty and (source == "distress" or source == "kill") and amount < 0 then
+      -- Only take a hit if in the faction's territory
+      local has_planet
+      for _, planet in ipairs(system.cur():planets()) do
+         if planet:faction() == _fthis then
+            has_planet = true
+            break
+         end
+      end
+      if not has_planet then
+         -- Planet belonging to this faction not found. Don't modify reputation.
+         return f
+      end
+   end
+
    -- Adjust for secondary hit
    if secondary then mod = mod * _fcap_mod_sec end
    amount = mod * amount
@@ -110,12 +129,12 @@ function default_hit( current, amount, source, secondary )
             -- We need to check if this happened in the faction's territory, otherwise it doesn't count.
             -- NOTE: virtual assets are NOT counted when determining territory!
             for _, planet in ipairs(system.cur():planets()) do
-                if planet:faction() == _fthis then
-                   -- Planet belonging to this faction found. Modify reputation.
-                   f = math.min( cap, f + math.min(delta[2], amount * clerp( f, 0, 1, cap, 0.2 )) )
-                   has_planet = true
-                   break
-                end
+               if planet:faction() == _fthis then
+                  -- Planet belonging to this faction found. Modify reputation.
+                  f = math.min( cap, f + math.min(delta[2], amount * clerp( f, 0, 1, cap, 0.2 )) )
+                  has_planet = true
+                  break
+               end
             end
             local witness = pilot.get( { _fthis } )
             if not has_planet and witness then

--- a/dat/factions/standing/trader.lua
+++ b/dat/factions/standing/trader.lua
@@ -8,6 +8,7 @@ _fdelta_distress = {-1.5, 0} -- Maximum change constraints
 _fdelta_kill     = {-7, 2} -- Maximum change constraints
 _fcap_misn     = 30 -- Starting mission cap, gets overwritten
 _fcap_misn_var = "_fcap_trader"
+_fextern_penalty = true
 _fthis         = faction.get("Trader")
 
 


### PR DESCRIPTION
This was something I suggested on IRC to get rid of the problem where
fighting Empire ships that join in fights against you with the Dvaered
negatively affects reputation. I'm not quite sure how well it works, since I haven't tested it yet.

One particular quirk with this is piracy in uninhabited systems has no
permanent consequences. But it could be that this isn't such a bad
thing.

One problem with this is it doesn't work for the FLF or traders, since
both of these factions are typically encountered nowhere near their
own territory. To solve this, I added a variable indicating whether
the old or new behavior should be used (default new), and set the FLF
and Trader faction to use the old behavior.