### PR TITLE
Abort, not End, autonav when hailed.

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -1607,7 +1607,7 @@ void player_hailStart (void)
 
    /* Abort autonav. */
    player_messageRaw("\erReceiving hail!");
-   player_autonavEnd();
+   player_autonavAbort(NULL);
 }
 
 


### PR DESCRIPTION
As long as we're doing it this way, we'd best be doing it properly.
player_autonavEnd is not meant to be used to suddenly stop Autonav,
and I don't know if it even works.