### PR TITLE
Don't offer pirate bounties in the current system.

### DIFF
--- a/dat/missions/neutral/pirbounty_dead.lua
+++ b/dat/missions/neutral/pirbounty_dead.lua
@@ -79,7 +79,7 @@ end
 function create ()
    paying_faction = planet.cur():faction()
 
-   local systems = getsysatdistance( system.cur(), 0, 3,
+   local systems = getsysatdistance( system.cur(), 1, 3,
       function(s) return s:presences()["Pirate"] end )
 
    if #systems == 0 then


### PR DESCRIPTION
I always get the same result when I get a pirate bounty in the current
system: I can't find the pirate, and it gets killed by someone else.
I could have solved this by making it spawn close to the planet, but
not doing this was a deliberate measure to prevent the player from
grinding in one system over and over again, so I've just removed the
option for bounties in the current system.